### PR TITLE
Configurable date format

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -147,7 +147,8 @@ local function show_blame_info()
         end
     end
     if info and info.author and info.author ~= 'Not Committed Yet' then
-        formatted_date = os.date('%c', os.time(info.date))
+        date_format = vim.g.gitblame_date_format
+        formatted_date = os.date(date_format, os.time(info.date))
 
         blame_text = vim.g.gitblame_message_template
         blame_text = blame_text:gsub('<author>',

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -56,7 +56,7 @@ local function process_blame_output(blames, filepath, lines)
                 info.author = author
             elseif line:match('^author%-time ') then
                 local text = line:gsub('^author%-time ', '')
-                info.date = os.date('*t', text)
+                info.date = text
             elseif line:match('^summary ') then
                 local text = line:gsub('^summary ', '')
                 info.summary = text
@@ -148,7 +148,7 @@ local function show_blame_info()
     end
     if info and info.author and info.author ~= 'Not Committed Yet' then
         date_format = vim.g.gitblame_date_format
-        formatted_date = os.date(date_format, os.time(info.date))
+        formatted_date = os.date(date_format, info.date)
 
         blame_text = vim.g.gitblame_message_template
         blame_text = blame_text:gsub('<author>',

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -147,9 +147,7 @@ local function show_blame_info()
         end
     end
     if info and info.author and info.author ~= 'Not Committed Yet' then
-        formatted_date = info.date.day .. '.' .. info.date.month .. '.' ..
-                             info.date.year .. ', ' .. info.date.hour .. ':' ..
-                             info.date.min
+        formatted_date = os.date('%c', os.time(info.date))
 
         blame_text = vim.g.gitblame_message_template
         blame_text = blame_text:gsub('<author>',

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -1,6 +1,7 @@
 highlight default link gitblame Comment
 let g:gitblame_enabled = get(g:, 'gitblame_enabled', 1)
 let g:gitblame_message_template = get(g:, 'gitblame_message_template', '  <author> • <date> • <summary>')
+let g:gitblame_date_format = get(g:, 'gitblame_date_format', '%c')
 
 function! GitBlameInit()
 	if g:gitblame_enabled == 0


### PR DESCRIPTION
Allow specifying the date format as in Lua's `os.date`.

I know, that only half-closes #7, but it is reasonable start (and also localizes at least the date format).