### PR TITLE
export check_file_in_git_repo

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -200,6 +200,7 @@ end
 
 return {
     init = init,
+    check_file_in_git_repo = check_file_in_git_repo,
     show_blame_info = show_blame_info,
     clear_virtual_text = clear_virtual_text,
     load_blames = load_blames,


### PR DESCRIPTION
On my neovim-0.4.4.0.git.15336.faa47eaff-1.fc33.x86_64 I could not use the plugin without exporting `check_file_in_git_repo`.