### PR TITLE
Enhance git root detection to support using in Repo

### DIFF
--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -1,5 +1,13 @@
 local M = {}
 
+function __FILE__() return debug.getinfo(3, 'S').source end
+function __LINE__() return debug.getinfo(3, 'l').currentline end
+function __FUNC__() return debug.getinfo(3, 'n').name end
+
+function M.log(text)
+    print(string.format('[%s][%s-%s] %s', os.clock(), __FUNC__(), __LINE__(), text))
+end
+
 ---@param cmd string
 ---@param opts table
 ---@return number | 'the job id'

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -29,8 +29,6 @@ function! GitBlameEnable()
 
 	let g:gitblame_enabled = 1
 	call GitBlameInit()
-	lua require('gitblame').check_file_in_git_repo()
-	lua require('gitblame').show_blame_info()
 endfunction
 
 function! GitBlameDisable()


### PR DESCRIPTION
When project is managed by Repo like Android, user may open
Vim in the project root which contains many git repositories.
Old way can not handle this usage well.
Meanwhile, Using git command to detect git root is slow and
make code complex. In this patch, finddir is used instead of
git commit, which is fast enough to simplify code logic and
compatible with more directory organizations.