### PR TITLE
Don't blame files/buffers outside of git

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -7,7 +7,7 @@ function M.check_is_ignored(callback)
     if filepath == "" then return true end
 
     utils.start_job('git check-ignore ' .. filepath,
-                    {on_exit = function(data) callback(data == 0) end})
+                    {on_exit = function(data) callback(data ~= 1) end})
 end
 
 ---@param sha string


### PR DESCRIPTION
The fix for issue #30 introduced a "Not Committed Yet" annotation for
untracked files in git repositories, but unfortunately also for files
entirely outside git repositories, diff views, and other buffers where
they don't make much sense.

Flip the `check_is_ignored` test so that it only returns false if a
buffer is backed by a file that is in a git repository and is not
ignored.