### PR TITLE
Don't show blame info for configured filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ Default: `1`
 let g:gitblame_display_virtual_text = 0
 ```
 
+#### Ignore by Filetype
+
+A list of filetypes for which gitblame information will not be displayed.
+
+Default: `[]`
+
+```vim
+let g:gitblame_ft_ignore = ['lua', 'c']
+```
+
 ## Commands
 #### Open the commit URL in browser
 `:GitBlameOpenCommitURL` opens the commit URL of commit under the cursor.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ A list of filetypes for which gitblame information will not be displayed.
 Default: `[]`
 
 ```vim
-let g:gitblame_ft_ignore = ['lua', 'c']
+let g:gitblame_ignored_filetypes = ['lua', 'c']
 ```
 
 ## Commands

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -101,7 +101,7 @@ local function load_blames(callback)
     if filepath == "" then return end
 
     local filetype = vim.api.nvim_buf_get_option(0, 'ft')
-    if vim.tbl_contains(vim.g.gitblame_ft_ignore, filetype) then return end
+    if vim.tbl_contains(vim.g.gitblame_ignored_filetypes, filetype) then return end
 
     git.get_repo_root(function(git_root)
         local command = 'git --no-pager -C ' .. git_root ..

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -100,6 +100,9 @@ local function load_blames(callback)
     local filepath = vim.api.nvim_buf_get_name(0)
     if filepath == "" then return end
 
+    local filetype = vim.api.nvim_buf_get_option(0, 'ft')
+    if utils.arr_contains(vim.g.gitblame_ft_ignore, filetype) then return end
+
     git.get_repo_root(function(git_root)
         local command = 'git --no-pager -C ' .. git_root ..
                             ' blame -b -p --date relative --contents - ' ..

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -101,7 +101,7 @@ local function load_blames(callback)
     if filepath == "" then return end
 
     local filetype = vim.api.nvim_buf_get_option(0, 'ft')
-    if utils.arr_contains(vim.g.gitblame_ft_ignore, filetype) then return end
+    if vim.tbl_contains(vim.g.gitblame_ft_ignore, filetype) then return end
 
     git.get_repo_root(function(git_root)
         local command = 'git --no-pager -C ' .. git_root ..

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -97,4 +97,13 @@ function M.launch_url(url)
     open_cmd(url)
 end
 
+function M.arr_contains(arr, val)
+    for _, ele in ipairs(arr) do
+        if ele == val then
+            return true
+        end
+    end
+    return false
+end
+
 return M

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -97,13 +97,4 @@ function M.launch_url(url)
     open_cmd(url)
 end
 
-function M.arr_contains(arr, val)
-    for _, ele in ipairs(arr) do
-        if ele == val then
-            return true
-        end
-    end
-    return false
-end
-
 return M

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -3,6 +3,7 @@ let g:gitblame_enabled = get(g:, 'gitblame_enabled', 1)
 let g:gitblame_message_template = get(g:, 'gitblame_message_template', '  <author> • <date> • <summary>')
 let g:gitblame_date_format = get(g:, 'gitblame_date_format', '%c')
 let g:gitblame_display_virtual_text = get(g:, 'gitblame_display_virtual_text', 1)
+let g:gitblame_ft_ignore = get(g:, 'gitblame_ft_ignore', [])
 execute "highlight default link gitblame " .. g:gitblame_highlight_group
 
 function! GitBlameInit()

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -3,7 +3,7 @@ let g:gitblame_enabled = get(g:, 'gitblame_enabled', 1)
 let g:gitblame_message_template = get(g:, 'gitblame_message_template', '  <author> • <date> • <summary>')
 let g:gitblame_date_format = get(g:, 'gitblame_date_format', '%c')
 let g:gitblame_display_virtual_text = get(g:, 'gitblame_display_virtual_text', 1)
-let g:gitblame_ft_ignore = get(g:, 'gitblame_ft_ignore', [])
+let g:gitblame_ignored_filetypes = get(g:, 'gitblame_ignored_filetypes', [])
 execute "highlight default link gitblame " .. g:gitblame_highlight_group
 
 function! GitBlameInit()


### PR DESCRIPTION
Hi,

Not sure if this is something you want for the plugin but it's a feature I was after.

If I have an `NvimTree`, `SymbolsOutline`, or whatever other "not really a file" buffer open, each line shows the `Not Committed Yet` virtual text. It's not really a problem but it is a little annoying.

I figure it would be useful to be able to disable the virtual text by filetype.