### PR TITLE
feat: Normalize remote url to use with GitBlameOpenCommitURL

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -14,7 +14,24 @@ end
 ---@param remote_url string
 ---@return string
 local function get_commit_url(sha, remote_url)
-    return remote_url .. '/commit/' .. sha
+    local commit_path = '/commit/' .. sha
+
+    local domain, path = string.match(remote_url, ".*git%@(.*)%:(.*)%.git")
+    if domain and path then
+      return 'https://' .. domain .. '/' .. path .. commit_path
+    end
+
+    local url = string.match(remote_url, ".*git%@(.*)%.git")
+    if url then
+      return 'https://' .. url .. commit_path
+    end
+
+    local https_url = string.match(remote_url, "(https%:%/%/.*)%.git")
+    if https_url then
+      return https_url .. commit_path
+    end
+
+    return remote_url .. commit_path
 end
 
 ---@param sha string


### PR DESCRIPTION
Hi,

I like a lot `GitBlameOpenCommitURL` command, but it was not working for me because some remote urls have the SSH URL version, like: 
```
git@github.com:someorg/some-repo.git
ssh://git@gitlab-master.MyCompany.com:12051/Me/PROJECT1.git
git@gitlab-master.MyCompany.com:Me/PROJECT1.git
git@bitbucket.org:Me/PROJECT2.git

```
and also because of the `.git` word at the end, like:
`https://github.com/f-person/git-blame.nvim.git`

I figured it would be helpful if we normalize the remote url to support all formats
