### PR TITLE
add -w options for git blame to avoid undefined commits

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -107,7 +107,7 @@ local function load_blames(callback)
 
     git.get_repo_root(function(git_root)
         local command = 'git --no-pager -C ' .. git_root ..
-                            ' blame -b -p --date relative --contents - ' ..
+                            ' blame -b -p -w --date relative --contents - ' ..
                             filepath
 
         start_job(command, {


### PR DESCRIPTION
I am not really sure why this is happening. I sometimes get these undefined commits when doing git blame --contents -

![Screenshot from 2022-05-01 17-55-51](https://user-images.githubusercontent.com/9444583/166141140-25a38343-5ce7-44b5-8b61-50b3437821c0.png)

I added the `-w` option and the commits show up
![Screenshot from 2022-05-01 17-56-49](https://user-images.githubusercontent.com/9444583/166141192-94eb00b0-118a-4276-9cc5-78871730ead9.png)

