### PR TITLE
Windows shell compatability

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -6,7 +6,7 @@ function M.check_is_ignored(callback)
     local filepath = vim.api.nvim_buf_get_name(0)
     if filepath == "" then return true end
 
-    utils.start_job('git check-ignore ' .. filepath,
+    utils.start_job('git check-ignore ' .. vim.fn.shellescape(filepath),
                     {on_exit = function(data) callback(data ~= 1) end})
 end
 
@@ -42,8 +42,8 @@ end
 function M.get_remote_url(callback)
     local filepath = utils.get_filepath()
     if not filepath then return end
-    local remote_url_command = 'cd "`dirname \'' .. filepath .. '\'`"' ..
-                                   " && git config --get remote.origin.url"
+    local remote_url_command = 'cd "`dirname ' .. vim.fn.shellescape(filepath) .. '`"' ..
+                                   ' && git config --get remote.origin.url'
 
     utils.start_job(utils.get_posix_shell_command(remote_url_command), {
         on_stdout = function(url)
@@ -60,7 +60,7 @@ end
 function M.get_repo_root(callback)
     local filepath = utils.get_filepath()
     if not filepath then return end
-    local command = 'cd "`dirname \'' .. filepath .. '\'`"' ..
+    local command = 'cd "`dirname ' .. vim.fn.shellescape(filepath) .. '`"' ..
                         ' && git rev-parse --show-toplevel'
 
     utils.start_job(utils.get_posix_shell_command(command),

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -40,12 +40,11 @@ end
 
 ---@param callback fun(url: string)
 function M.get_remote_url(callback)
-    local filepath = utils.get_filepath()
-    if not filepath then return end
-    local remote_url_command = 'cd "`dirname ' .. vim.fn.shellescape(filepath) .. '`"' ..
+    if not utils.get_filepath() then return end
+    local remote_url_command = 'cd ' .. vim.fn.shellescape(vim.fn.expand('%:p:h')) ..
                                    ' && git config --get remote.origin.url'
 
-    utils.start_job(utils.get_posix_shell_command(remote_url_command), {
+    utils.start_job(remote_url_command, {
         on_stdout = function(url)
             if url and url[1] then
                 callback(url[1])
@@ -58,13 +57,11 @@ end
 
 ---@param callback fun()
 function M.get_repo_root(callback)
-    local filepath = utils.get_filepath()
-    if not filepath then return end
-    local command = 'cd "`dirname ' .. vim.fn.shellescape(filepath) .. '`"' ..
+    if not utils.get_filepath() then return end
+    local command = 'cd ' .. vim.fn.shellescape(vim.fn.expand('%:p:h')) ..
                         ' && git rev-parse --show-toplevel'
 
-    utils.start_job(utils.get_posix_shell_command(command),
-                    {on_stdout = function(data) callback(data[1]) end})
+    utils.start_job(command, {on_stdout = function(data) callback(data[1]) end})
 end
 
 return M

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -106,9 +106,9 @@ local function load_blames(callback)
     end
 
     git.get_repo_root(function(git_root)
-        local command = 'git --no-pager -C ' .. git_root ..
+        local command = 'git --no-pager -C ' .. vim.fn.shellescape(git_root) ..
                             ' blame -b -p -w --date relative --contents - ' ..
-                            filepath
+                            vim.fn.shellescape(filepath)
 
         start_job(command, {
             input = table.concat(lines, '\n') .. '\n',

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -56,14 +56,6 @@ end
 ---@return number
 function M.get_line_number() return vim.api.nvim_win_get_cursor(0)[1] end
 
----Returns a command which will be ran in `sh`. This is useful in cases
----where user's default shell is not POSIX-compliant.
----@param command string
----@return string
-function M.get_posix_shell_command(command)
-    return "echo '" .. command .. "' | sh"
-end
-
 ---Merges map entries of `source` into `target`.
 ---@param source table<any, any>
 ---@param target table<any, any>

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -73,7 +73,7 @@ function M.launch_url(url)
     if not open_cmd then
         if package.config:sub(1, 1) == '\\' then
             open_cmd = function(_url)
-                M.start_job(string.format('start "%s"', _url))
+                M.start_job(string.format('rundll32 url.dll,FileProtocolHandler "%s"', _url))
             end
         elseif (io.popen("uname -s"):read '*a'):match 'Darwin' then
             open_cmd = function(_url)


### PR DESCRIPTION
This escapes filepaths in the git commands and eliminates the usage of `get_posix_shell_command`, which required `sh` and `dirname` to be on the user path, allowing Windows users to use the plugin. It addresses issues #49 and #53.
The original `:GitBlameOpenCommitURL` also didn't work on Windows due to the `start` command not opening URLs when double quotes are present. Instead of deleting the quotes, I opted to do what `netrw#BrowseX()` (gx) does and use `url.dll` directly, which also allows the command to work on Windows if for some reason powershell or something else is the selected shell instead of cmd.