### PR TITLE
Fix MacOS unable to open link URLs

### DIFF
--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -75,7 +75,7 @@ function M.launch_url(url)
             open_cmd = function(_url)
                 M.start_job(string.format('rundll32 url.dll,FileProtocolHandler "%s"', _url))
             end
-        elseif (io.popen("uname -s"):read '*a'):match 'Darwin' then
+        elseif (io.popen("uname -s"):read '*a'):match 'Darwin\n' then
             open_cmd = function(_url)
                 M.start_job(string.format('open "%s"', _url))
             end


### PR DESCRIPTION
The OS-agnostic URL opener implementation provided by https://stackoverflow.com/a/18864453/9714875 doesn't work for MacOS systems because `uname` appends a newline character to the end of the output. Adding a newline character fixes the handler.