### PR TITLE
feat: Add custom message when not committed yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Available options: `<author>`, `<committer>`, `<date>`, `<committer-date>`, `<su
 let g:gitblame_message_template = '<summary> • <date> • <author>'
 ```
 
+#### Message when not committed yet
+The blame message that will be shown when the current modification 
+hasn't been committed yet.
+
+Default: `'  Not Committed Yet'`
+
+```vim
+let g:gitblame_message_when_not_committed = 'Oh please, commit this !'
+```
+
 #### Date format
 The [format](https://www.lua.org/pil/22.1.html) of the date fields.
 

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -30,6 +30,11 @@ local current_blame_text
 ---@return string
 local function get_date_format() return vim.g.gitblame_date_format end
 
+--@return string
+local function get_message_when_not_committed()
+  return vim.g.gitblame_message_when_not_committed
+end
+
 local function clear_virtual_text()
     vim.api.nvim_buf_del_extmark(0, NAMESPACE_ID, 1)
 end
@@ -168,7 +173,7 @@ local function get_blame_text(filepath, blame_info, callback)
                                      info.committer and info.committer_date and
                                      info.author ~= 'Not Committed Yet'
 
-    local notCommitedBlameText = '  Not Committed Yet'
+    local notCommitedBlameText = get_message_when_not_committed()
     if isBlameInfoAvailable then
         local blame_text = vim.g.gitblame_message_template
         blame_text = blame_text:gsub('<author>',

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -1,6 +1,7 @@
 let g:gitblame_highlight_group = get(g:, 'gitblame_highlight_group', "Comment")
 let g:gitblame_enabled = get(g:, 'gitblame_enabled', 1)
 let g:gitblame_message_template = get(g:, 'gitblame_message_template', '  <author> • <date> • <summary>')
+let g:gitblame_message_when_not_committed = get(g:, 'gitblame_message_when_not_committed','  Not Committed Yet')
 let g:gitblame_date_format = get(g:, 'gitblame_date_format', '%c')
 let g:gitblame_display_virtual_text = get(g:, 'gitblame_display_virtual_text', 1)
 let g:gitblame_ignored_filetypes = get(g:, 'gitblame_ignored_filetypes', [])


### PR DESCRIPTION
Hi,

I just discover your plugin (an hour ago) and it's really awesome.
However, I saw that it's missing a feature that I liked in other blame plugins. So I added the feature for customizing the message
when a modification is not yet committed. 

By default, the message is ` Not Committed Yet` but now everyone can customize it.
I added how to do it in the README.md file.

> PS: this is my first ever open source contribution and I'm pretty excited 😁