### PR TITLE
[FIX] get_blame_info returns nil when files_data is nil

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -188,7 +188,7 @@ end
 ---@param linenumber number
 ---@return BlameInfo|nil
 local function get_blame_info(filepath, linenumber)
-    if not filepath and not files_data[filepath] then
+    if not filepath or not files_data[filepath] then
         return nil
     end
 


### PR DESCRIPTION
Ensure `load_blames` is called when a command is called while the plugin is disabled. Allows commands like GitBlameCopySHA to work when the plugin is disabled.

Fixes regression of https://github.com/f-person/git-blame.nvim/issues/47.
