### PR TITLE
feat: open file url

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,17 @@ the system's clipboard.
 ### Copy Commit URL
 
 `:GitBlameCopyCommitURL` copies the commit URL of current line's commit into
-the system's clipboard.
+the system clipboard.
+
+### Open file URL in browser
+
+`:GitBlameOpenFileURL` opens the file (with a mark set on the current line) in
+the browser.
+
+### Copy file URL
+
+`:GitBlameCopyFileURL` copies the file URL into the system clipboard.
+
 
 ## Statusline integration
 

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -41,7 +41,25 @@ end
 ---@param filepath string
 ---@param line_number number?
 ---@return string
-function M.get_file_url(remote_url, branch,filepath, line_number)
+function M.get_file_url(filepath, line_number, callback)
+    M.get_repo_root(function (root)
+      local relative_filepath = string.sub(filepath, #root + 2)
+
+      M.get_current_branch(function(branch)
+        M.get_remote_url(function(remote_url)
+          local url = M._get_file_url(remote_url, branch, relative_filepath, line_number)
+          callback(url)
+        end)
+      end)
+    end)
+end
+
+---@param remote_url string
+---@param branch string
+---@param filepath string
+---@param line_number number?
+---@return string
+function M._get_file_url(remote_url, branch, filepath, line_number)
     local file_path = "/blob/" .. branch .. "/" .. filepath
 
     local repo_url = M.get_repo_url(remote_url)
@@ -66,15 +84,8 @@ end
 ---@param filepath string
 ---@param line_number number?
 function M.open_file_in_browser(filepath, line_number)
-    M.get_repo_root(function (root)
-      local relative_filepath = string.sub(filepath, #root + 2)
-
-      M.get_current_branch(function(branch)
-        M.get_remote_url(function(remote_url)
-          local url = M.get_file_url(remote_url, branch, relative_filepath, line_number)
-          utils.launch_url(url)
-        end)
-      end)
+    M.get_file_url(filepath, line_number, function(url)
+        utils.launch_url(url)
     end)
 end
 

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -42,7 +42,6 @@ end
 ---@param line_number number?
 ---@return string
 function M.get_file_url(remote_url, branch,filepath, line_number)
-  -- https://github.com/moliva/git-utils/blob/master/scripts/build.sh
     local file_path = "/blob/" .. branch .. "/" .. filepath
 
     local repo_url = M.get_repo_url(remote_url)

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -404,7 +404,7 @@ end
 local function open_file_url()
     local filepath = utils.get_filepath()
     if (filepath == nil) then
-      return ""
+      return
     end
 
     local line_number = utils.get_line_number()
@@ -433,7 +433,7 @@ end
 local function copy_file_url_to_clipboard()
     local filepath = utils.get_filepath()
     if (filepath == nil) then
-      return ""
+      return
     end
 
     local line_number = utils.get_line_number()

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -430,6 +430,19 @@ local function copy_sha_to_clipboard()
     end)
 end
 
+local function copy_file_url_to_clipboard()
+    local filepath = utils.get_filepath()
+    if (filepath == nil) then
+      return ""
+    end
+
+    local line_number = utils.get_line_number()
+
+    git.get_file_url(filepath, line_number, function(url)
+        utils.copy_to_clipboard(url)
+    end)
+end
+
 local function copy_commit_url_to_clipboard()
     get_sha(function(sha)
         if sha then
@@ -479,5 +492,6 @@ return {
     is_blame_text_available = is_blame_text_available,
     copy_sha_to_clipboard = copy_sha_to_clipboard,
     copy_commit_url_to_clipboard = copy_commit_url_to_clipboard,
+    copy_file_url_to_clipboard = copy_file_url_to_clipboard,
     disable = disable,
 }

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -401,6 +401,17 @@ local function open_commit_url()
     end)
 end
 
+local function open_file_url()
+    local filepath = utils.get_filepath()
+    if (filepath == nil) then
+      return ""
+    end
+
+    local line_number = utils.get_line_number()
+
+    git.open_file_in_browser(filepath, line_number)
+end
+
 local function get_current_blame_text()
     return current_blame_text
 end
@@ -463,6 +474,7 @@ return {
     handle_text_changed = handle_text_changed,
     handle_insert_leave = handle_insert_leave,
     open_commit_url = open_commit_url,
+    open_file_url = open_file_url,
     get_current_blame_text = get_current_blame_text,
     is_blame_text_available = is_blame_text_available,
     copy_sha_to_clipboard = copy_sha_to_clipboard,

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -47,6 +47,10 @@ function! GitBlameToggle()
 	endif
 endfunction
 
+function! GitBlameOpenFileURL()
+    lua require('gitblame').open_file_url()
+endfunction
+
 function! GitBlameOpenCommitURL() 
     lua require('gitblame').open_commit_url()
 endfunction
@@ -63,6 +67,7 @@ endfunction
 :command! -nargs=0 GitBlameEnable call GitBlameEnable()
 :command! -nargs=0 GitBlameDisable call GitBlameDisable()
 :command! -nargs=0 GitBlameOpenCommitURL call GitBlameOpenCommitURL()
+:command! -nargs=0 GitBlameOpenFileURL call GitBlameOpenFileURL()
 :command! -nargs=0 GitBlameCopySHA call GitBlameCopySHA()
 :command! -nargs=0 GitBlameCopyCommitURL call GitBlameCopyCommitURL()
 

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -63,6 +63,10 @@ function! GitBlameCopyCommitURL()
     lua require('gitblame').copy_commit_url_to_clipboard()
 endfunction
 
+function! GitBlameCopyFileURL()
+    lua require('gitblame').copy_file_url_to_clipboard()
+endfunction
+
 :command! -nargs=0 GitBlameToggle call GitBlameToggle()
 :command! -nargs=0 GitBlameEnable call GitBlameEnable()
 :command! -nargs=0 GitBlameDisable call GitBlameDisable()
@@ -70,5 +74,6 @@ endfunction
 :command! -nargs=0 GitBlameOpenFileURL call GitBlameOpenFileURL()
 :command! -nargs=0 GitBlameCopySHA call GitBlameCopySHA()
 :command! -nargs=0 GitBlameCopyCommitURL call GitBlameCopyCommitURL()
+:command! -nargs=0 GitBlameCopyFileURL call GitBlameCopyFileURL()
 
 call GitBlameInit()


### PR DESCRIPTION
Providing these functionalities I used from GitLenses to this plugin, as they've been really helpful to me.

- Adds the command `GitBlameOpenFileURL` to open a browser tab with the currently open file (and line)
- Adds the command `GitBlameCopyFileURL` to copy the currently open file (and line) URL to the clipboard