### PR TITLE
Fix incorrect commit url for bitbucket repositories

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -15,6 +15,21 @@ function M.check_is_ignored(callback)
     })
 end
 
+---@param sha string
+---@param remote_url string
+---@return string
+local function get_commit_path(sha, remote_url)
+    local domain = string.match(remote_url, ".*git%@(.*)%:.*")
+        or string.match(remote_url, "https%:%/%/.*%@(.*)%/.*")
+        or string.match(remote_url, "https%:%/%/(.*)%/.*")
+
+    if domain and domain:lower() == "bitbucket.org" then
+        return "/commits/" .. sha
+    end
+
+    return "/commit/" .. sha
+end
+
 ---@param remote_url string
 ---@return string
 local function get_repo_url(remote_url)
@@ -91,7 +106,7 @@ end
 ---@param remote_url string
 ---@return string
 function M.get_commit_url(sha, remote_url)
-    local commit_path = "/commit/" .. sha
+    local commit_path = get_commit_path(sha, remote_url)
 
     local repo_url = get_repo_url(remote_url)
     return repo_url .. commit_path


### PR DESCRIPTION
Hello! I noticed that bitbucket commit urls were giving me a "Resource not found" error when attempting to visit them in the browser.

The path for individual commits within bitbucket.org is `/commits/` instead of `/commit/` for bitbucket.org.

I've updated the relevant code here. Let me know what you think. Thanks!