### PR TITLE
Handle remote urls without .git suffix

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -33,6 +33,21 @@ local function get_repo_url(remote_url)
         return https_url
     end
 
+    domain, path = string.match(remote_url, ".*git%@(.*)%:(.*)")
+    if domain and path then
+        return "https://" .. domain .. "/" .. path
+    end
+
+    url = string.match(remote_url, ".*git%@(.*)")
+    if url then
+        return "https://" .. url
+    end
+
+    https_url = string.match(remote_url, "(https%:%/%/.*)")
+    if https_url then
+        return https_url
+    end
+
     return remote_url
 end
 


### PR DESCRIPTION
Hello again, I've also noticed that this plugin does not handle remote urls without a .git suffix gracefully.

.git suffixes are optional with remote urls and repositories function without that suffix just fine.

I've updated the relevant function to do a fallback check on each url structure without the .git suffix before returning the default remote_url.

Let me know your thoughts on this change. Thanks!