### PR TITLE
feat: Add specify start column for blame message

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A git blame plugin for Neovim written in Lua
   - [Virtual text enabled](#virtual-text-enabled)
   - [Ignore by Filetype](#ignore-by-filetype)
   - [Visual delay for displaying the blame info](#visual-delay-for-displaying-the-blame-info)
+  - [Start virtual text at column](#start-virtual-text-at-column)
 - [Commands](#commands)
   - [Open the commit URL in browser](#open-the-commit-url-in-browser)
   - [Enable/Disable git blame messages](#enabledisable-git-blame-messages)
@@ -184,6 +185,18 @@ Default: `0`
 
 ```vim
 let g:gitblame_delay = 1000 " 1 second
+```
+
+### Start virtual text at column
+
+Have the blame message start at a given column instead of EOL. If the current
+line is longer than the specified column value the blame message will default
+to being displayed at EOL.
+
+Default: `v:null`
+
+```vim
+let g:gitblame_virtual_text_column = 80
 ```
 
 ## Commands

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -262,9 +262,17 @@ local function update_blame_text(blame_text)
     end
     current_blame_text = blame_text
 
+    local virt_text_column = nil
+    if vim.g.gitblame_virtual_text_column ~= vim.NIL
+        and utils.get_line_length() < vim.g.gitblame_virtual_text_column
+    then
+        virt_text_column = vim.g.gitblame_virtual_text_column
+    end
+
     local should_display_virtual_text = vim.g.gitblame_display_virtual_text == 1
     if should_display_virtual_text then
-        local options = { id = 1, virt_text = { { blame_text, "gitblame" } } }
+        local options = { id = 1, virt_text = { { blame_text, "gitblame" } },
+            virt_text_win_col = virt_text_column }
         local user_options = vim.g.gitblame_set_extmark_options or {}
         if type(user_options) == "table" then
             utils.merge_map(user_options, options)

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -81,6 +81,10 @@ function M.get_line_number()
     return vim.api.nvim_win_get_cursor(0)[1]
 end
 
+function M.get_line_length()
+    return string.len(vim.api.nvim_get_current_line())
+end
+
 ---Merges map entries of `source` into `target`.
 ---@param source table<any, any>
 ---@param target table<any, any>

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -6,6 +6,7 @@ let g:gitblame_date_format = get(g:, 'gitblame_date_format', '%c')
 let g:gitblame_display_virtual_text = get(g:, 'gitblame_display_virtual_text', 1)
 let g:gitblame_ignored_filetypes = get(g:, 'gitblame_ignored_filetypes', [])
 let g:gitblame_delay = get(g:, 'gitblame_delay', 0)
+let g:gitblame_virtual_text_column = get(g:, 'gitblame_virtual_text_column', v:null)
 
 execute "highlight default link gitblame " .. g:gitblame_highlight_group
 


### PR DESCRIPTION
This feature allows the user to specify a column from which the blame message should start. If the line is longer than the specified column value for a given line it will use the default behavior (display at EOL) for that line.