### PR TITLE
fix: Handle info sometimes being nil for uncommitted lines

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -224,7 +224,7 @@ local function format_blame_text(info, template)
     local summary_escaped = info.summary:gsub("%%", "%%%%")
     text = text:gsub("<summary>", summary_escaped)
 
-    text = text:gsub("<sha>", string.sub(info.sha, 1, 7))
+    text = text:gsub("<sha>", info.sha and string.sub(info.sha, 1, 7) or "")
 
     return text
 end
@@ -273,6 +273,7 @@ local function get_blame_text(filepath, info, callback)
         info.committer_date = info.committer_date or os.time()
 
         if #files_data[filepath].blames > 0 then
+
             local blame_text = format_blame_text(info, get_uncommitted_message_template())
             callback(blame_text)
         else

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -258,24 +258,26 @@ local function get_blame_text(filepath, info, callback)
     else
         if info then
             info = utils.shallowcopy(info)
-
-            info.author = "You"
-            info.committer = "You"
-            info.summary = "Not Commited Yet"
-
-            -- NOTE: While this works okay-ish, I'm not sure this is the behavior
-            -- people expect, since sometimes git-blame just doesn't provide
-            -- the date of uncommited changes.
-            info.date = info.date or os.time()
-            info.committer_date = info.committer_date or os.time()
+        else
+            info = {}
         end
+
+        info.author = "You"
+        info.committer = "You"
+        info.summary = "Not Commited Yet"
+
+        -- NOTE: While this works okay-ish, I'm not sure this is the behavior
+        -- people expect, since sometimes git-blame just doesn't provide
+        -- the date of uncommited changes.
+        info.date = info.date or os.time()
+        info.committer_date = info.committer_date or os.time()
 
         if #files_data[filepath].blames > 0 then
             local blame_text = format_blame_text(info, get_uncommitted_message_template())
             callback(blame_text)
         else
             git.check_is_ignored(function(is_ignored)
-                local result = (not is_ignored and info) and format_blame_text(info, get_uncommitted_message_template())
+                local result = not is_ignored and format_blame_text(info, get_uncommitted_message_template())
                     or nil
                 callback(result)
             end)


### PR DESCRIPTION
I've run into some errors after 7aed504.
The issue happens consistently when writing some characters in a new line at the bottom of a file and then exiting insert mode.

My changes guarantee that all fields which are substituted in format_blame_text (except the commit sha) are present for an uncommitted line.
I figured that the sha should be an empty string if it doesn't exist.