### PR TITLE
feat: scope file urls to the latest commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,10 @@ the system clipboard.
 
 ### Open file URL in browser
 
-`:GitBlameOpenFileURL` opens the file (with a mark set on the current line) in
-the browser.
+`:GitBlameOpenFileURL` opens the file in the default browser.
+
+The URL is scoped to the latest commit on the current branch and
+has a mark of the current line. (same is true for `GitBlameCopyFileURL`)
 
 ### Copy file URL
 

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -452,6 +452,16 @@ local function handle_insert_leave()
     )
 end
 
+---Returns SHA for the latest commit to the current branch.
+---@param callback fun(sha: string)
+local function get_latest_sha(callback)
+    start_job('git rev-parse head', {
+        on_stdout = function(data)
+            callback(data[1])
+        end,
+    })
+end
+
 ---Returns SHA for the current line.
 ---@param callback fun(sha: string)
 local function get_sha(callback)
@@ -490,7 +500,9 @@ local function open_file_url()
 
     local line_number = utils.get_line_number()
 
-    git.open_file_in_browser(filepath, line_number)
+    get_latest_sha(function(sha)
+        git.open_file_in_browser(filepath, sha, line_number)
+    end)
 end
 
 local function get_current_blame_text()
@@ -519,8 +531,10 @@ local function copy_file_url_to_clipboard()
 
     local line_number = utils.get_line_number()
 
-    git.get_file_url(filepath, line_number, function(url)
-        utils.copy_to_clipboard(url)
+    get_latest_sha(function(sha)
+        git.get_file_url(filepath, sha, line_number, function(url)
+            utils.copy_to_clipboard(url)
+        end)
     end)
 end
 


### PR DESCRIPTION
The `GitBlameOpenFileURL` and `GitBlameCopyFileURL` commands construct file urls based on the remote url's current branch but disregard information that may have been committed since then, causing these commands to sometimes return the wrong line numbers. To fix this, I have modified these commands to use the latest commit SHA in the constructed file url. I believe this also fixes https://github.com/f-person/git-blame.nvim/issues/87.