### PR TITLE
fix: use HEAD instead of head

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -455,7 +455,7 @@ end
 ---Returns SHA for the latest commit to the current branch.
 ---@param callback fun(sha: string)
 local function get_latest_sha(callback)
-    start_job('git rev-parse head', {
+    start_job('git rev-parse HEAD', {
         on_stdout = function(data)
             callback(data[1])
         end,


### PR DESCRIPTION
This fixes a bug I introduced in https://github.com/f-person/git-blame.nvim/pull/94 :sweat: 

`HEAD` doesn't always equal `head` depending on how you clone a repo, but `HEAD` will always point to the checked out commit in the working directory. Whoops!

![image](https://github.com/f-person/git-blame.nvim/assets/35381535/4eeed0bd-9197-4719-9d98-1e72c2fd5830)
