### PR TITLE
feat: add optional range to file URLs

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -69,17 +69,20 @@ end
 ---@param remote_url string
 ---@param branch string
 ---@param filepath string
----@param line_number number?
+---@param line1 number?
+---@param line2 number?
 ---@return string
-local function get_file_url(remote_url, branch, filepath, line_number)
+local function get_file_url(remote_url, branch, filepath, line1, line2)
     local file_path = "/blob/" .. branch .. "/" .. filepath
 
     local repo_url = get_repo_url(remote_url)
 
-    if line_number == nil then
+    if line1 == nil then
         return repo_url .. file_path
+    elseif line2 == nil or line1 == line2 then
+        return repo_url .. file_path .. "#L" .. line1
     else
-        return repo_url .. file_path .. "#L" .. line_number
+        return repo_url .. file_path .. "#L" .. line1 .. '-L' .. line2
     end
 end
 
@@ -103,22 +106,23 @@ end
 
 ---@param filepath string
 ---@param sha string?
----@param line_number number?
+---@param line1 number?
+---@param line2 number?
 ---@param callback fun(url: string)
-function M.get_file_url(filepath, sha, line_number, callback)
+function M.get_file_url(filepath, sha, line1, line2, callback)
     M.get_repo_root(function(root)
         local relative_filepath = string.sub(filepath, #root + 2)
 
         if sha == nil then
             get_current_branch(function(branch)
                 M.get_remote_url(function(remote_url)
-                    local url = get_file_url(remote_url, branch, relative_filepath, line_number)
+                    local url = get_file_url(remote_url, branch, relative_filepath, line1, line2)
                     callback(url)
                 end)
             end)
         else
             M.get_remote_url(function(remote_url)
-                local url = get_file_url(remote_url, sha, relative_filepath, line_number)
+                local url = get_file_url(remote_url, sha, relative_filepath, line1, line2)
                 callback(url)
             end)
         end
@@ -137,9 +141,10 @@ end
 
 ---@param filepath string
 ---@param sha string?
----@param line_number number?
-function M.open_file_in_browser(filepath, sha, line_number)
-    M.get_file_url(filepath, sha, line_number, function(url)
+---@param line1 number?
+---@param line2 number?
+function M.open_file_in_browser(filepath, sha, line1, line2)
+    M.get_file_url(filepath, sha, line1, line2, function(url)
         utils.launch_url(url)
     end)
 end

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -73,15 +73,22 @@ end
 ---@param line2 number?
 ---@return string
 local function get_file_url(remote_url, branch, filepath, line1, line2)
-    local file_path = "/blob/" .. branch .. "/" .. filepath
-
     local repo_url = get_repo_url(remote_url)
+    local isSrcHut = repo_url:find('git.sr.ht')
+
+    local file_path = "/blob/" .. branch .. "/" .. filepath
+    if isSrcHut then
+        file_path = "/tree/" .. branch .. "/" .. filepath
+    end
 
     if line1 == nil then
         return repo_url .. file_path
     elseif line2 == nil or line1 == line2 then
         return repo_url .. file_path .. "#L" .. line1
     else
+        if isSrcHut then
+            return repo_url .. file_path .. "#L" .. line1 .. '-' .. line2
+        end
         return repo_url .. file_path .. "#L" .. line1 .. '-L' .. line2
     end
 end

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -492,16 +492,20 @@ local function open_commit_url()
     end)
 end
 
-local function open_file_url()
+-- See :h nvim_create_user_command for more information.
+---@class CommandArgs
+---@field line1 number
+---@field line2 number
+
+---@param args CommandArgs
+local function open_file_url(args)
     local filepath = utils.get_filepath()
     if filepath == nil then
         return
     end
 
-    local line_number = utils.get_line_number()
-
     get_latest_sha(function(sha)
-        git.open_file_in_browser(filepath, sha, line_number)
+        git.open_file_in_browser(filepath, sha, args.line1, args.line2)
     end)
 end
 
@@ -523,16 +527,15 @@ local function copy_sha_to_clipboard()
     end)
 end
 
-local function copy_file_url_to_clipboard()
+---@param args CommandArgs
+local function copy_file_url_to_clipboard(args)
     local filepath = utils.get_filepath()
     if filepath == nil then
         return
     end
 
-    local line_number = utils.get_line_number()
-
     get_latest_sha(function(sha)
-        git.get_file_url(filepath, sha, line_number, function(url)
+        git.get_file_url(filepath, sha, args.line1, args.line2, function(url)
             utils.copy_to_clipboard(url)
         end)
     end)

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -51,10 +51,6 @@ function! GitBlameToggle()
 	endif
 endfunction
 
-function! GitBlameOpenFileURL()
-    lua require('gitblame').open_file_url()
-endfunction
-
 function! GitBlameOpenCommitURL() 
     lua require('gitblame').open_commit_url()
 endfunction
@@ -67,17 +63,13 @@ function! GitBlameCopyCommitURL()
     lua require('gitblame').copy_commit_url_to_clipboard()
 endfunction
 
-function! GitBlameCopyFileURL()
-    lua require('gitblame').copy_file_url_to_clipboard()
-endfunction
-
 :command! -nargs=0 GitBlameToggle call GitBlameToggle()
 :command! -nargs=0 GitBlameEnable call GitBlameEnable()
 :command! -nargs=0 GitBlameDisable call GitBlameDisable()
 :command! -nargs=0 GitBlameOpenCommitURL call GitBlameOpenCommitURL()
-:command! -nargs=0 GitBlameOpenFileURL call GitBlameOpenFileURL()
+lua vim.api.nvim_create_user_command('GitBlameOpenFileURL', require('gitblame').open_file_url, { range = true })
 :command! -nargs=0 GitBlameCopySHA call GitBlameCopySHA()
 :command! -nargs=0 GitBlameCopyCommitURL call GitBlameCopyCommitURL()
-:command! -nargs=0 GitBlameCopyFileURL call GitBlameCopyFileURL()
+lua vim.api.nvim_create_user_command('GitBlameCopyFileURL', require('gitblame').copy_file_url_to_clipboard, { range = true })
 
 call GitBlameInit()


### PR DESCRIPTION
After playing around a bit with `GitBlameOpenFileURL` and `GItBlameCopyFileURL` I thought it would be a great idea to add optional range functionality to the line selection. You would be able to select ranges of lines to reference, and many git repository hosting platforms support line ranges. If you execute one of these commands with a range (i.e. `:74,84GitBlameOpenFileURL`) or with a visual selection, the resulting URL will have the range highlighted ([here is an example range](https://github.com/f-person/git-blame.nvim/blob/02fadac1702c014ce49a9499137d798934bdb465/lua/gitblame/git.lua#L74-L84)). Otherwise, the existing behavior (selecting an individual line) will work as expected.

I tested in Github, Gitlab, and SourceHut repos (SourceHut uses a slightly different URL pattern).