### PR TITLE
fix: Changing highlight_group from lua config does not work

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -304,6 +304,11 @@ local function update_blame_text(blame_text)
     end
 
     local should_display_virtual_text = vim.g.gitblame_display_virtual_text == 1
+
+    if #vim.api.nvim_get_hl(0, { name = "gitblame" }) == 0 then
+        vim.api.nvim_set_hl(0, "gitblame", { link = vim.g.gitblame_highlight_group })
+    end
+
     if should_display_virtual_text then
         local options = {
             id = 1,

--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -8,7 +8,6 @@ let g:gitblame_ignored_filetypes = get(g:, 'gitblame_ignored_filetypes', [])
 let g:gitblame_delay = get(g:, 'gitblame_delay', 0)
 let g:gitblame_virtual_text_column = get(g:, 'gitblame_virtual_text_column', v:null)
 
-execute "highlight default link gitblame " .. g:gitblame_highlight_group
 
 function! GitBlameInit()
 	if g:gitblame_enabled == 0


### PR DESCRIPTION
Highlight link was set in gitblame.vim before parsing lua config which made lua config ineffective.