### PR TITLE
fix: Modify file URL commands to open relative latest commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A git blame plugin for Neovim written in Lua
   - [Ignore by Filetype](#ignore-by-filetype)
   - [Visual delay for displaying the blame info](#visual-delay-for-displaying-the-blame-info)
   - [Start virtual text at column](#start-virtual-text-at-column)
+  - [Use blame commit file URLs](#use-blame-commit-file-urls)
 - [Commands](#commands)
   - [Open the commit URL in browser](#open-the-commit-url-in-browser)
   - [Enable/Disable git blame messages](#enabledisable-git-blame-messages)
@@ -218,6 +219,16 @@ Default: `v:null`
 
 ```vim
 let g:gitblame_virtual_text_column = 80
+```
+
+## Use blame commit file URLs
+
+By default the commands `GitBlameOpenFileURL` and `GitBlameCopyFileURL` open the current file at latest branch commit. If you would like to open these files at the latest blame commit (in other words, the commit marked by the blame), set this to true. For ranges, the blame selected will be the most recent blame from the range.
+
+Default: `false`
+
+```lua
+vim.g.gitblame_use_blame_commit_file_urls = true
 ```
 
 ## Commands

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -503,8 +503,6 @@ end
 local function get_sha(callback, line1, line2)
     local filepath = utils.get_filepath()
     local line_number = line1 or utils.get_line_number()
-
-    -- TODO improve error handling for uncommitted lines
     local info = get_blame_info(filepath, line_number, line2)
 
     if info then

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -643,7 +643,7 @@ end
 ---@field display_virtual_text boolean
 ---@field ignored_filetypes string[]
 ---@field delay number @Visual delay for displaying virtual text
----@field use_blame_commit_file_urls boolean Use the latest blame commit instead of the latest branch commit for file urls.
+---@field use_blame_commit_file_urls boolean? Use the latest blame commit instead of the latest branch commit for file urls.
 ---@field virtual_text_column nil|number @The column on which to start displaying virtual text
 
 ---@param opts SetupOptions

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -453,16 +453,6 @@ local function handle_insert_leave()
     )
 end
 
----Returns SHA for the latest commit to the current branch.
----@param callback fun(sha: string)
-local function get_latest_sha(callback)
-    start_job("git rev-parse HEAD", {
-        on_stdout = function(data)
-            callback(data[1])
-        end,
-    })
-end
-
 ---Returns SHA for the current line.
 ---@param callback fun(sha: string)
 local function get_sha(callback)
@@ -505,7 +495,7 @@ local function open_file_url(args)
         return
     end
 
-    get_latest_sha(function(sha)
+    get_sha(function(sha)
         git.open_file_in_browser(filepath, sha, args.line1, args.line2)
     end)
 end
@@ -535,7 +525,7 @@ local function copy_file_url_to_clipboard(args)
         return
     end
 
-    get_latest_sha(function(sha)
+    get_sha(function(sha)
         git.get_file_url(filepath, sha, args.line1, args.line2, function(url)
             utils.copy_to_clipboard(url)
         end)

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -238,8 +238,15 @@ local function get_blame_info(filepath, line1, line2)
     end
     if line2 and line1 ~= line2 then
         local blame_range = get_range_blame_info(filepath, line1, line2)
-        -- TODO find most recent blame
-        return blame_range[1]
+        ---@type BlameInfo|nil
+        local latest_blame = nil
+        for _, blame in ipairs(blame_range) do
+            if latest_blame == nil or blame.date > latest_blame.date then
+                latest_blame = blame
+            end
+        end
+
+        return latest_blame
     else
         return get_line_blame_info(filepath, line1)
     end


### PR DESCRIPTION
Based on the conversation in https://github.com/f-person/git-blame.nvim/issues/103, we have decided to open file URLs using the SHA of the blame commit rather than the most recent upstream commit to prevent 404s when the upstream is out of date. I accomplished this by modifying `get_blame_info` to accept a range of lines and fetch the most recent blame from the lines provided, and modifying `get_sha` to accept an optional range of lines. Then I removed `get_latest_sha`.