### PR TITLE
fix: Virtual text is still rendered when gitblame_display_virtual_text is 0

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -343,7 +343,7 @@ local function update_blame_text(blame_text)
         virt_text_column = vim.g.gitblame_virtual_text_column
     end
 
-    if not vim.g.gitblame_display_virtual_text then
+    if vim.g.gitblame_display_virtual_text == false or vim.g.gitblame_display_virtual_text == 0 then
         return
     end
     local options = {


### PR DESCRIPTION
Virtual text is still rendered when gitblame_display_virtual_text is 0

This bug occurs because nvim and vim treat 0 differently.