### PR TITLE
fix: reset current_blame_text when disable

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -639,7 +639,7 @@ M.disable = function(force)
     if not vim.g.gitblame_enabled and not force then
         return
     end
-
+    current_blame_text = ""
     vim.g.gitblame_enabled = false
     pcall(vim.api.nvim_del_augroup_by_name, "gitblame")
     clear_all_extmarks()

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -639,12 +639,13 @@ M.disable = function(force)
     if not vim.g.gitblame_enabled and not force then
         return
     end
-    current_blame_text = ""
+    
     vim.g.gitblame_enabled = false
     pcall(vim.api.nvim_del_augroup_by_name, "gitblame")
     clear_all_extmarks()
     clear_files_data()
     last_position = {}
+    current_blame_text = nil
 end
 
 M.enable = function()


### PR DESCRIPTION
I'm using lualine and when I run GitBlameDisable, the statusline still shows the text of the last time GitBlame was used