### PR TITLE
fix: get_sha incorrectly used as global function

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -556,7 +556,7 @@ M.open_file_url = function(args)
     end
 
     if vim.g.gitblame_use_blame_commit_file_urls then
-        get_sha(callback, args.line1, args.line2)
+        M.get_sha(callback, args.line1, args.line2)
     else
         get_latest_sha(callback)
     end
@@ -595,7 +595,7 @@ M.copy_file_url_to_clipboard = function(args)
     end
 
     if vim.g.gitblame_use_blame_commit_file_urls then
-        get_sha(callback, args.line1, args.line2)
+        M.get_sha(callback, args.line1, args.line2)
     else
         get_latest_sha(callback)
     end


### PR DESCRIPTION
When setting `vim.g.gitblame_use_blame_commit_file_urls = true` and running the command `:GitBlameOpenCommitURL`, this error occurs:
```
E5108: Error executing lua: Vim:Error executing Lua callback: ...cal/share/nvim/lazy/git-blame.nvim/lua/gitblame/init.lua:559: attempt to call global 'get_sha' (a nil value)
stack traceback:
        ...cal/share/nvim/lazy/git-blame.nvim/lua/gitblame/init.lua:559: in function <...cal/share/nvim/lazy/git-blame.nvim/lua/gitblame/init.lua:547>
        [C]: at 0x0102436920
stack traceback:
        [C]: at 0x0102436920
```

`get_sha` is defined on `M`, so calling `M.get_sha` fixes this.