### PR TITLE
fix: add fallbacks for url commands

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -118,6 +118,8 @@ end
 ---@param callback fun(url: string)
 function M.get_file_url(filepath, sha, line1, line2, callback)
     M.get_repo_root(function(root)
+        -- if outside a repository, return the filepath
+        -- so we can still copy the path or open the file
         if root == "" then
             callback(filepath)
             return

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -74,7 +74,7 @@ end
 ---@return string
 local function get_file_url(remote_url, branch, filepath, line1, line2)
     local repo_url = get_repo_url(remote_url)
-    local isSrcHut = repo_url:find('git.sr.ht')
+    local isSrcHut = repo_url:find("git.sr.ht")
 
     local file_path = "/blob/" .. branch .. "/" .. filepath
     if isSrcHut then
@@ -87,9 +87,9 @@ local function get_file_url(remote_url, branch, filepath, line1, line2)
         return repo_url .. file_path .. "#L" .. line1
     else
         if isSrcHut then
-            return repo_url .. file_path .. "#L" .. line1 .. '-' .. line2
+            return repo_url .. file_path .. "#L" .. line1 .. "-" .. line2
         end
-        return repo_url .. file_path .. "#L" .. line1 .. '-L' .. line2
+        return repo_url .. file_path .. "#L" .. line1 .. "-L" .. line2
     end
 end
 
@@ -118,6 +118,11 @@ end
 ---@param callback fun(url: string)
 function M.get_file_url(filepath, sha, line1, line2, callback)
     M.get_repo_root(function(root)
+        if root == "" then
+            callback(filepath)
+            return
+        end
+
         local relative_filepath = string.sub(filepath, #root + 2)
 
         if sha == nil then

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -500,6 +500,13 @@ local function get_latest_sha(callback)
     })
 end
 
+---@param sha string?
+---@return boolean
+local function is_valid_sha(sha)
+    local empty_sha = "0000000000000000000000000000000000000000"
+    return sha ~= nil and sha ~= "" and sha ~= empty_sha
+end
+
 ---Returns SHA for the current line or SHA
 ---for the latest commit in visual selection
 ---@param callback fun(sha: string)
@@ -522,9 +529,7 @@ end
 
 M.open_commit_url = function()
     M.get_sha(function(sha)
-        local empty_sha = "0000000000000000000000000000000000000000"
-
-        if sha and sha ~= "" and sha ~= empty_sha then
+        if is_valid_sha(sha) then
             git.open_commit_in_browser(sha)
         else
             utils.log("Unable to open commit URL as SHA is empty")
@@ -566,7 +571,7 @@ end
 
 M.copy_sha_to_clipboard = function()
     M.get_sha(function(sha)
-        if sha and sha ~= "" then
+        if is_valid_sha(sha) then
             utils.copy_to_clipboard(sha)
         else
             utils.log("Unable to copy SHA")
@@ -597,7 +602,7 @@ end
 
 M.copy_commit_url_to_clipboard = function()
     M.get_sha(function(sha)
-        if sha and sha ~= "" then
+        if is_valid_sha(sha) then
             git.get_remote_url(function(remote_url)
                 local commit_url = git.get_commit_url(sha, remote_url)
                 utils.copy_to_clipboard(commit_url)

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -39,9 +39,6 @@ local date_format_has_relative_time
 ---@type string
 local current_blame_text
 
----@type table timer luv timer object
-local delay_timer
-
 ---@return string
 local function get_date_format()
     return vim.g.gitblame_date_format
@@ -527,7 +524,7 @@ M.open_commit_url = function()
     M.get_sha(function(sha)
         local empty_sha = "0000000000000000000000000000000000000000"
 
-        if sha and sha ~= empty_sha then
+        if sha and sha ~= "" and sha ~= empty_sha then
             git.open_commit_in_browser(sha)
         else
             utils.log("Unable to open commit URL as SHA is empty")
@@ -569,7 +566,7 @@ end
 
 M.copy_sha_to_clipboard = function()
     M.get_sha(function(sha)
-        if sha then
+        if sha and sha ~= "" then
             utils.copy_to_clipboard(sha)
         else
             utils.log("Unable to copy SHA")
@@ -600,7 +597,7 @@ end
 
 M.copy_commit_url_to_clipboard = function()
     M.get_sha(function(sha)
-        if sha then
+        if sha and sha ~= "" then
             git.get_remote_url(function(remote_url)
                 local commit_url = git.get_commit_url(sha, remote_url)
                 utils.copy_to_clipboard(commit_url)

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -3,9 +3,11 @@ local M = {}
 function __FILE__()
     return debug.getinfo(3, "S").source
 end
+
 function __LINE__()
     return debug.getinfo(3, "l").currentline
 end
+
 function __FUNC__()
     return debug.getinfo(3, "n").name
 end
@@ -158,8 +160,8 @@ function M.shallowcopy(orig)
 end
 
 -- debounce function
---- @param func function the function which will be wrapped
---- @param delay  integer time, millisecond
+---@param func function the function which will be wrapped
+---@param delay  integer time, millisecond
 function M.debounce(func, delay)
     local timer = nil
     return function(...)


### PR DESCRIPTION
## Problem

While investigating https://github.com/f-person/git-blame.nvim/issues/117 I noticed that the urls generated by `GitBlameOpenCommitURL`, `GitBlameOpenFileURL`, `GitBlameCopyCommitURL`, and `GitBlameCopyFileURL` can sometimes have incorrect fallback values when used outside of a git repository. I fixed these commands so that the provide a reasonable fallback value or log to the command output.

## Verification

Run the commands above and verify they provide a reasonable output for git repositories and other non-repository directories!