### PR TITLE
fix: Clear virtual text immediately on cursor move

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -692,7 +692,7 @@ local function maybe_clear_virtual_text_and_schedule_info_display()
         clear_virtual_text()
     end
 
-    debounce(schedule_show_info_display, math.floor(500))()
+    debounce(schedule_show_info_display, math.floor(vim.g.gitblame_delay))()
 end
 
 local function set_autocmds()

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -159,23 +159,4 @@ function M.shallowcopy(orig)
     return copy
 end
 
--- debounce function
----@param func function the function which will be wrapped
----@param delay  integer time, millisecond
-function M.debounce(func, delay)
-    local timer = nil
-    return function(...)
-        local args = { ... }
-        if timer then
-            timer:stop()
-            timer = nil
-        end
-
-        timer = vim.defer_fn(function()
-            func(unpack(args))
-            timer = nil
-        end, delay)
-    end
-end
-
 return M


### PR DESCRIPTION
The PR #121 introduced some side-effects which made the plugin feel more laggy overall because of how the virtual text got cleared with a delay. This commit retains the original delay behavior for displaying, while immediately clearing the virtual text on cursor move.

Previous behavior: 

https://github.com/f-person/git-blame.nvim/assets/31893391/59f68069-7741-4af3-9857-c130f1c5877b

Current behavior:

https://github.com/f-person/git-blame.nvim/assets/31893391/49c8e320-8e63-480d-bf44-c5a70c725f7b

@bossley9 this doesn't yet switch the default to 0 since it's probably good to 1) reconsider doing that after this change (i would probably still be in favor of that), 2) nicer to do in a separate PR
