### PR TITLE
docs: add German language on changing lua-timeago languages

### DIFF
--- a/lua/lua-timeago/languages/de.lua
+++ b/lua/lua-timeago/languages/de.lua
@@ -1,0 +1,9 @@
+return {
+    justnow = "Gerade eben",
+    minute = { singular = "Eine Minute her", plural = "Minuten her" },
+    hour = { singular = "Eine Stunde her", plural = "Stunden her" },
+    day = { singular = "Einen Tag her", plural = "Tage her" },
+    week = { singular = "Eine Woche her", plural = "Wochen her" },
+    month = { singular = "Einen Monat her", plural = "Monate her" },
+    year = { singular = "Ein Jahr her", plural = "Jahre her" },
+}


### PR DESCRIPTION
I wanted this plugin to support the German language. As to the translations, it's not the most optimal, but a good enough one. A really good one would look like this

```lua
return {
    justnow = "Gerade eben",
    minute = { singular = "Vor einer Minute", plural = "Vor {} Minuten" },
    hour = { singular = "Vor einer Stunde", plural = "Vor {} Stunden" },
    day = { singular = "Vor einem Tag", plural = "Vor {} Tagen" },
    week = { singular = "Vor einer Woche", plural = "Vor {} Wochen" },
    month = { singular = "Vor einem Monat", plural = "Vor {} Monaten" },
    year = { singular = "Vor einem Jahr", plural = "Vor {} Jahren" },
}
```

but since this plugin doesn't support it, I adjusted the translations so it works with the plugin. I think the translation is still pretty good. 