### PR TITLE
feat: add support for azure repos

### DIFF
--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -41,7 +41,6 @@ local function get_azure_url(url)
     end
 
     org, project, repo = string.match(url, "(.*)/(.*)/(.*)")
-
     if org and project and repo then
         return 'https://dev.azure.com/' .. org .. "/" .. project .. "/_git/" .. repo
     end
@@ -119,7 +118,7 @@ local function get_file_url(remote_url, branch, filepath, line1, line2)
         return repo_url .. file_path
     elseif line2 == nil or line1 == line2 then
         if isAzure then
-            return repo_url .. file_path .. "&line=" .. line1 .. "&lineEnd=" .. line1 + 1 .. "&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents"
+            return repo_url .. file_path .. "&line=" .. line1 .. "&lineEnd=" .. line1 + 1 .. "&lineStartColumn=1&lineEndColumn=1"
         end
 
         return repo_url .. file_path .. "#L" .. line1
@@ -129,7 +128,7 @@ local function get_file_url(remote_url, branch, filepath, line1, line2)
         end
 
         if isAzure then
-            return repo_url .. file_path .. "&line=" .. line1 .. "&lineEnd=" .. line2 + 1 .. "&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents"
+            return repo_url .. file_path .. "&line=" .. line1 .. "&lineEnd=" .. line2 + 1 .. "&lineStartColumn=1&lineEndColumn=1"
         end
 
         return repo_url .. file_path .. "#L" .. line1 .. "-L" .. line2

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -49,7 +49,6 @@ local function get_azure_url(url)
     return url
 end
 
-
 ---@param remote_url string
 ---@return string
 local function get_repo_url(remote_url)

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -33,7 +33,6 @@ end
 ---@param url string
 ---@return string
 local function get_azure_url(url)
-
     -- HTTPS has a different URL format
     local org, project, repo = string.match(url, "(.*)/(.*)/_git/(.*)")
     if org and project and repo then

--- a/lua/gitblame/git.lua
+++ b/lua/gitblame/git.lua
@@ -56,7 +56,7 @@ local function get_repo_url(remote_url)
         return "https://" .. domain .. "/" .. path
     end
 
-    local url = string.match(remote_url, ".*git@*ssh.dev.azure.com:v3/(.*)")
+    local url = string.match(remote_url, ".*git@*ssh.dev.azure.com:v[0-9]/(.*)")
     if url then
         return get_azure_url(url)
     end


### PR DESCRIPTION
Hi,

As we've discussed in #117, the URLs produced by the plugin's command aren't compatible with Azure since Azure uses different format than other git providers.

This PR adds support for Azure repos, let me know what you think about it. 