### PR TITLE
Fixes bug with nil current_blame_text

### DIFF
--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -566,7 +566,7 @@ M.get_current_blame_text = function()
 end
 
 M.is_blame_text_available = function()
-    return current_blame_text ~= ""
+    return current_blame_text and current_blame_text ~= ""
 end
 
 M.copy_sha_to_clipboard = function()


### PR DESCRIPTION
There is a bug currently where if `current_blame_text` is `nil` (which it will be if you are _not_ in a git repo), `is_blame_available` will return true and you will get `nil` displayed in your statusline.

This fixes that by adding a check for if not nil as well as not an empty string.