### PR TITLE
config: allow configure custom clipboard register

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ Default: `false`
 vim.g.gitblame_use_blame_commit_file_urls = true
 ```
 
+### Configuring the clipboard register
+
+By default the `:GitBlameCopySHA`, `:GitBlameCopyFileURL` and `:GitBlameCopyCommitURL` commands use the `+` register. Set this value if you would like to use a different register (such as `*`).
+
+Default: `+`
+
+```vim
+let g:gitblame_clipboard_register = "*"
+```
+
 ## Commands
 
 ### Open the commit URL in browser

--- a/lua/gitblame/config.lua
+++ b/lua/gitblame/config.lua
@@ -15,6 +15,7 @@ M.default_opts = {
     use_blame_commit_file_urls = false,
     schedule_event = "CursorMoved",
     clear_event = "CursorMovedI",
+    clipboard_register = "+",
 }
 
 ---@param opts SetupOptions?

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -789,6 +789,7 @@ end
 ---@field delay number? Visual delay for displaying virtual text
 ---@field use_blame_commit_file_urls boolean? Use the latest blame commit instead of the latest branch commit for file urls.
 ---@field virtual_text_column number? The column on which to start displaying virtual text
+---@field clipboard_register string? The clipboard register to use when copying commit SHAs or file URLs 
 
 ---@param opts SetupOptions?
 M.setup = function(opts)

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -133,7 +133,7 @@ end
 
 ---@param text string
 function M.copy_to_clipboard(text)
-    vim.fn.setreg("+", text)
+    vim.fn.setreg(vim.g.gitblame_clipboard_register, text)
 end
 
 ---@param command string


### PR DESCRIPTION
First off, thanks for this! I've been using it for a while and it's really useful :)

I have a (somewhat) weird setup, where I use neovim over SSH with X11 forwarding (with XQuartz on my macOS host) so that I can share my clipboard, and hence the `:GitblameCopy..` commands don't work for me unless I apply a patch to use another clipboard register.

Another option here would be to use the vim option as opposed to hardcoded "+", such as `vim.opt.clipboard`. I'm happy to change to that too. (I made a PR using that approach here: https://github.com/f-person/git-blame.nvim/pull/137)