### PR TITLE
utils: use `vim.opt.clipboard` instead of hardcoded `+`

### DIFF
--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -133,7 +133,7 @@ end
 
 ---@param text string
 function M.copy_to_clipboard(text)
-    vim.fn.setreg("+", text)
+    vim.fn.setreg(vim.opt.clipboard, text)
 end
 
 ---@param command string


### PR DESCRIPTION
Alternative to https://github.com/f-person/git-blame.nvim/pull/136 using `vim.opt.clipboard`.