### PR TITLE
feat: configurable commit summary length

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A git blame plugin for Neovim written in Lua
   - [Start virtual text at column](#start-virtual-text-at-column)
   - [Better Performance](#better-performance)
   - [Use blame commit file URLs](#use-blame-commit-file-urls)
+  - [Set displayed commit summary length](#set-displayed-commit-summary-length)
 - [Commands](#commands)
   - [Open the commit URL in browser](#open-the-commit-url-in-browser)
   - [Enable/Disable git blame messages](#enabledisable-git-blame-messages)
@@ -279,6 +280,17 @@ Default: `+`
 
 ```vim
 let g:gitblame_clipboard_register = "*"
+```
+
+### Set displayed commit summary length
+
+The maximum length of the commit summary shown in the blame message.
+If the commit summary is longer than this value, it will be truncated.
+
+Default: `0 (full length)`
+
+```vim
+let g:gitblame_max_commit_summary_length = 50
 ```
 
 ## Commands

--- a/lua/gitblame/config.lua
+++ b/lua/gitblame/config.lua
@@ -16,6 +16,7 @@ M.default_opts = {
     schedule_event = "CursorMoved",
     clear_event = "CursorMovedI",
     clipboard_register = "+",
+    max_commit_summary_length = 0,
 }
 
 ---@param opts SetupOptions?

--- a/lua/gitblame/init.lua
+++ b/lua/gitblame/init.lua
@@ -289,7 +289,7 @@ local function format_blame_text(info, template)
     text = text:gsub("<date>", format_date(info.date))
 
     local summary_escaped = info.summary and info.summary:gsub("%%", "%%%%") or ""
-    text = text:gsub("<summary>", summary_escaped)
+    text = text:gsub("<summary>", utils.truncate_description(summary_escaped, vim.g.gitblame_max_commit_summary_length))
 
     text = text:gsub("<sha>", info.sha and string.sub(info.sha, 1, 7) or "")
 
@@ -789,7 +789,8 @@ end
 ---@field delay number? Visual delay for displaying virtual text
 ---@field use_blame_commit_file_urls boolean? Use the latest blame commit instead of the latest branch commit for file urls.
 ---@field virtual_text_column number? The column on which to start displaying virtual text
----@field clipboard_register string? The clipboard register to use when copying commit SHAs or file URLs 
+---@field clipboard_register string? The clipboard register to use when copying commit SHAs or file URLs
+---@field max_commit_summary_length number? The maximum allowable length for the displayed commit summary. Defaults to 0 (no limit)
 
 ---@param opts SetupOptions?
 M.setup = function(opts)

--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -159,4 +159,14 @@ function M.shallowcopy(orig)
     return copy
 end
 
+---@param description string
+---@param max_length number
+---@return string
+function M.truncate_description(description, max_length)
+    if max_length ~= 0 and string.len(description) > max_length then
+        return string.sub(description, 1, max_length) .. "..."
+    end
+    return description
+end
+
 return M


### PR DESCRIPTION
Solves issue #139 

"It would be nice if the description part of the blame could be configured to only show the first n characters for a more consistent output length."