### PR TITLE
feat: floating window for blame message

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ the system clipboard.
 The URL is scoped to the latest commit on the current branch and
 has a mark of the current line. (same is true for `GitBlameCopyFileURL`)
 
+`:GitBlameToggleCommitMesgWindow` open a floating window to display the commit message of the current line.
+
 ### Copy file URL
 
 `:GitBlameCopyFileURL` copies the file URL into the system clipboard.


### PR DESCRIPTION
hello!

I found it's kind of hard to see the full commit message when using virtual text, so I created a command to display a floating window so we don't have to resize my terminal every time

<img width="902" alt="Screenshot 2025-05-26 at 5 36 18 PM" src="https://github.com/user-attachments/assets/aa112fb9-ca9f-458f-9588-74848ca96213" />

