### PR TITLE
fix: use vim.ui.open() for nvim-0.10+

### DIFF
--- a/lua/gitblame/utils.lua
+++ b/lua/gitblame/utils.lua
@@ -112,6 +112,11 @@ local open_cmd
 ---Source: https://stackoverflow.com/a/18864453/9714875
 ---@param url string
 function M.launch_url(url)
+    if vim.fn.has("nvim-0.10") then
+        vim.ui.open(url)
+        return
+    end
+
     if not open_cmd then
         if package.config:sub(1, 1) == "\\" then
             open_cmd = function(_url)


### PR DESCRIPTION
Based on https://github.com/f-person/git-blame.nvim/pull/152 the custom URL opener doesn't work for Nushell. Now that Neovim includes its own native `vim.ui.open()` since v0.10 we should prioritize using this when supported while maintaining backwards compatibility with older versions.